### PR TITLE
Add command to expand selection from current position to start and end of subword

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,4 +14,5 @@ subwordNavigation.cursorSubwordLeftSelect
 subwordNavigation.cursorSubwordRightSelect
 subwordNavigation.deleteSubwordLeft
 subwordNavigation.deleteSubwordRight
+subwordNavigation.expandSubwordSelection
 ```

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
         "onCommand:subwordNavigation.cursorSubwordRightSelect",
         "onCommand:subwordNavigation.deleteSubwordLeft",
         "onCommand:subwordNavigation.deleteSubwordRight",
-        "onCommand.subwordNavigation.expandSubwordSelection"
+        "onCommand:subwordNavigation.expandSubwordSelection"
     ],
     "main": "./out/extension",
     "contributes": {
@@ -73,7 +73,7 @@
             },
             {
                 "command": "subwordNavigation.expandSubwordSelection",
-                "key": "alt++shift+w",
+                "key": "alt+shift+w",
                 "mac": "ctrl+shift+up",
                 "when": "editorTextFocus && !editorReadonly"
                 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
         "onCommand:subwordNavigation.cursorSubwordRightSelect",
         "onCommand:subwordNavigation.deleteSubwordLeft",
         "onCommand:subwordNavigation.deleteSubwordRight",
-        "onCommand.subwordNavigation.expandSubwordSelection"
+        "onCommand:subwordNavigation.expandSubwordSelection"
     ],
     "main": "./out/extension",
     "contributes": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
         "onCommand:subwordNavigation.cursorSubwordLeftSelect",
         "onCommand:subwordNavigation.cursorSubwordRightSelect",
         "onCommand:subwordNavigation.deleteSubwordLeft",
-        "onCommand:subwordNavigation.deleteSubwordRight"
+        "onCommand:subwordNavigation.deleteSubwordRight",
+        "onCommand.subwordNavigation.expandSubwordSelection"
     ],
     "main": "./out/extension",
     "contributes": {
@@ -69,6 +70,13 @@
                 "key": "alt+delete",
                 "mac": "ctrl+delete",
                 "when": "editorTextFocus && !editorReadonly"
+            },
+            {
+                "command": "subwordNavigation.expandSubwordSelection",
+                "key": "alt++shift+w",
+                "mac": "ctrl+shift+up",
+                "when": "editorTextFocus && !editorReadonly"
+                
             }
         ]
     },

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -25,6 +25,11 @@ export function deleteSubwordRight(editor: TextEditor) {
     deleteSubword(editor, right);
 }
 
+export function expandSubwordSelection(editor: TextEditor) {
+    editor.selections = editor.selections.map(s => new Selection(left(editor.document, s.active), right(editor.document, s.active)))
+    reveal(editor)
+}
+
 function cursorSubword(editor: TextEditor, next: BoundaryFunc, sel: SelectionFunc) {
     editor.selections = editor.selections.map(s => sel(s, next(editor.document, s.active)));
     reveal(editor);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -25,4 +25,8 @@ export function activate() {
     commands.registerCommand(
         'subwordNavigation.deleteSubwordRight',
         () => subwordNavigation.deleteSubwordRight(window.activeTextEditor));
+
+    commands.registerCommand(
+        'subwordNavigation.expandSubwordSelection',
+        () => subwordNavigation.expandSubwordSelection(window.activeTextEditor));
 }


### PR DESCRIPTION
Added a command, bound by default to alt-shift-w or ctrl-shift-up (based on similar InteliJ shortcuts) that expands selection in both directions to the beginning and end of the current subword.